### PR TITLE
Add aesKeySize and interactiveOverwrite options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ From a security standpoint, committing things like passwords or API keys to a VC
 The generic API consists of three keys:
 
 * `secretFiles` - a list of files that contain secrets, and thus need to be managed by sbt-secrets. **These files _must_ be ignored by the VCS**. These files should be minimal and not include any non-secret data. In practice, most repos will have only secret file.
+* `interactiveOverwrite` - Whether to prompt when overwriting existing files.
+* `aesKeySize` - The AES key-size to use for encryption and decryption. Defaults to 128. 256 bits requires the Java Cryptography Extension.
 * `encryptSecretFiles` - encrypts the files specified by `secretFiles`, storing the results in files alongside the originals, with suffix `.encrypted`.
 * `decryptSecretFiles` - decrypts `.encrypted` files, storing the results back in the original files specified by `secretFiles`.
 

--- a/src/main/scala/com/evenfinancial/sbt/secrets/KeybaseSecrets.scala
+++ b/src/main/scala/com/evenfinancial/sbt/secrets/KeybaseSecrets.scala
@@ -5,7 +5,7 @@ import com.evenfinancial.sbt.secrets.util._
 
 object KeybaseSecrets extends AutoPlugin {
 
-  override def requires = Secrets
+  override def requires: Secrets.type = Secrets
 
   object autoImport {
 
@@ -32,7 +32,7 @@ object KeybaseSecrets extends AutoPlugin {
 
     decryptSecretFiles := {
       secretFiles.value.map { file =>
-        SbtUtil.promptForOverwrite(file) {
+        SbtUtil.promptForOverwrite(file, interactiveOverwrite.value) {
           val encryptedFile = SbtUtil.fileWithSuffix(file, ".encrypted")
           (Process.cat(encryptedFile) #| Seq("keybase", "pgp", "decrypt") #> file).!
         }

--- a/src/main/scala/com/evenfinancial/sbt/secrets/KmsSecrets.scala
+++ b/src/main/scala/com/evenfinancial/sbt/secrets/KmsSecrets.scala
@@ -5,18 +5,15 @@ import com.evenfinancial.sbt.secrets.util._
 
 object KmsSecrets extends AutoPlugin {
 
-  override def requires = Secrets
+  override def requires: Secrets.type = Secrets
 
   object autoImport {
 
-    val encryptedKmsDataKeyFile = settingKey[File](
-      "The file containing the encrypted KMS data key."
-    )
+    val encryptedKmsDataKeyFile = settingKey[File]("The file containing the encrypted KMS data key.")
 
-    val kmsDataKey = taskKey[String](
-      "The data key used to encrypt / decrypt files."
-    )
+    val kmsDataKey = taskKey[String]("The data key used to encrypt / decrypt files.")
 
+    val kmsKeyId = taskKey[Option[String]]("A unique identifier for the customer master key (CMK).")
   }
 
   import Secrets.autoImport._
@@ -26,13 +23,18 @@ object KmsSecrets extends AutoPlugin {
 
     encryptedKmsDataKeyFile := file("./encrypted-kms-data-key.txt"),
 
-    kmsDataKey := KmsUtil.decryptDataKey(IO.read(encryptedKmsDataKeyFile.value)),
+    kmsDataKey := KmsUtil.decryptDataKey(
+      encryptedDataKey = IO.read(encryptedKmsDataKeyFile.value),
+      kmsKeyId = kmsKeyId.value),
+
+    kmsKeyId := None,
 
     encryptSecretFiles := {
       val dataKey = kmsDataKey.value
+      val secretKeySpec = AesUtil.buildSecretKey(dataKey, aesKeySize.value)
 
       secretFiles.value.map { file =>
-        val encryptedData = AesUtil.encrypt(IO.read(file), dataKey)
+        val encryptedData = AesUtil.encrypt(IO.read(file), secretKeySpec)
         val _encryptedFile = SbtUtil.fileWithSuffix(file, ".encrypted")
         IO.write(_encryptedFile, encryptedData)
         _encryptedFile
@@ -41,11 +43,12 @@ object KmsSecrets extends AutoPlugin {
 
     decryptSecretFiles := {
       val dataKey = kmsDataKey.value
+      val secretKeySpec = AesUtil.buildSecretKey(dataKey, aesKeySize.value)
 
       secretFiles.value.map { file =>
-        SbtUtil.promptForOverwrite(file) {
+        SbtUtil.promptForOverwrite(file, interactiveOverwrite.value) {
           val _encryptedFile = SbtUtil.fileWithSuffix(file, ".encrypted")
-          val decryptedData = AesUtil.decrypt(IO.read(_encryptedFile), dataKey)
+          val decryptedData = AesUtil.decrypt(IO.read(_encryptedFile), secretKeySpec)
           IO.write(file, decryptedData)
         }
 

--- a/src/main/scala/com/evenfinancial/sbt/secrets/Secrets.scala
+++ b/src/main/scala/com/evenfinancial/sbt/secrets/Secrets.scala
@@ -5,27 +5,18 @@ import sbt._
 object Secrets extends AutoPlugin {
 
   object autoImport {
-
-    val secretFiles = settingKey[Seq[File]](
-      "Files containing secrets that cannot be commited unencrypted to SCM."
-    )
-
-    val encryptSecretFiles = taskKey[Seq[File]](
-      "Encrypt all files specified by `secretFiles`."
-    )
-
-    val decryptSecretFiles = taskKey[Seq[File]](
-      "Decrypt all encrypted files corresponding to those specified by `secretFiles`."
-    )
-
+    val secretFiles = settingKey[Seq[File]]("Files containing secrets that cannot be commited unencrypted to SCM.")
+    val interactiveOverwrite = settingKey[Boolean]("Whether to prompt when overwriting existing files.")
+    val aesKeySize = settingKey[Int]("The AES key-size to use for encryption and decryption. Defaults to 128. 256 bits requires the Java Cryptography Extension.")
+    val encryptSecretFiles = taskKey[Seq[File]]("Encrypt all files specified by `secretFiles`.")
+    val decryptSecretFiles = taskKey[Seq[File]]("Decrypt all encrypted files corresponding to those specified by `secretFiles`.")
   }
 
   import autoImport._
 
   override def projectSettings = Seq(
-
-    secretFiles := Seq.empty
-
+    secretFiles := Seq.empty,
+    interactiveOverwrite := true,
+    aesKeySize := 128
   )
-
 }

--- a/src/main/scala/com/evenfinancial/sbt/secrets/util/KmsUtil.scala
+++ b/src/main/scala/com/evenfinancial/sbt/secrets/util/KmsUtil.scala
@@ -9,7 +9,9 @@ object KmsUtil {
 
   lazy val client = new AWSKMSClient()
 
-  def decryptDataKey(encryptedDataKey: String): String = {
+  def decryptDataKey(
+                      encryptedDataKey: String,
+                      kmsKeyId: Option[String] = None): String = {
     val byteBuffer = ByteBuffer.wrap(Base64.getDecoder.decode(encryptedDataKey.trim))
     val decryptRequest = new DecryptRequest().withCiphertextBlob(byteBuffer)
     val decryptResult = client.decrypt(decryptRequest)

--- a/src/main/scala/com/evenfinancial/sbt/secrets/util/SbtUtil.scala
+++ b/src/main/scala/com/evenfinancial/sbt/secrets/util/SbtUtil.scala
@@ -6,32 +6,35 @@ object SbtUtil {
 
   lazy val consoleLogger = ConsoleLogger()
 
-  def promptForOverwrite(file: File)(overwrite: => Unit) {
+  def promptForOverwrite(file: File, interactiveOverwrite: Boolean)(overwrite: => Unit) {
     if (file.exists) {
-      val action = SimpleReader.readLine(s"${file.getName} already exists: (o)verwrite, (b)ackup or (s)kip? [o] ")
+      if (interactiveOverwrite) {
+        val action = SimpleReader.readLine(s"${file.getName} already exists: (o)verwrite, (b)ackup or (s)kip? [o] ")
 
-      action.get match {
-        case "" | "o" | "overwrite" => {
-          consoleLogger.warn(s"overwriting ${file.getName}")
-          overwrite
+        action.get match {
+
+          case "" | "o" | "overwrite" =>
+            consoleLogger.warn(s"overwriting ${file.getName}")
+            overwrite
+
+          case "b" | "backup" =>
+            val backup = fileWithSuffix(file, ".backup")
+            consoleLogger.info(s"backing up ${file.getName} to ${backup.getName}")
+            IO.transfer(file, backup)
+            overwrite
+
+          case "s" | "skip" =>
+            consoleLogger.warn(s"not overwriting ${file.getName}")
+
+          case invalid =>
+            consoleLogger.error(s"Invalid response: $invalid")
+            promptForOverwrite(file = file, interactiveOverwrite = interactiveOverwrite)(overwrite)
         }
-        case "b" | "backup" => {
-          val backup = fileWithSuffix(file, ".backup")
-          consoleLogger.info(s"backing up ${file.getName} to ${backup.getName}")
-          IO.transfer(file, backup)
-          overwrite
-        }
-        case "s" | "skip" => {
-          consoleLogger.warn(s"not overwriting ${file.getName}")
-        }
-        case invalid => {
-          consoleLogger.error(s"Invalid response: ${invalid}")
-          promptForOverwrite(file)(overwrite)
-        }
+      } else {
+        consoleLogger.warn(s"Overwriting file ${file.getName}...")
+        overwrite
       }
-    } else {
-      overwrite
-    }
+    } else overwrite
   }
 
   def fileWithSuffix(file: File, suffix: String): File = {

--- a/src/test/scala/com/evenfinancial/sbt/secrets/util/AesUtilSpec.scala
+++ b/src/test/scala/com/evenfinancial/sbt/secrets/util/AesUtilSpec.scala
@@ -2,29 +2,26 @@ package com.evenfinancial.sbt.secrets.util
 
 import org.scalatest.{WordSpec, MustMatchers}
 
-class AesUtilSpec
-  extends WordSpec
-  with MustMatchers
+class AesUtilSpec extends WordSpec with MustMatchers
 {
-
   "AesUtil" must {
-
     "encrypt and then decrypt transparently" in {
       val data = "data"
       val key = "key"
-      val encryptedData = AesUtil.encrypt(data, key)
+      val secretKeySpec = AesUtil.buildSecretKey(key, 128)
+      val encryptedData = AesUtil.encrypt(data, secretKeySpec)
       encryptedData must not be data
-      val decryptedData = AesUtil.decrypt(encryptedData, key)
+      val decryptedData = AesUtil.decrypt(encryptedData, secretKeySpec)
       decryptedData mustBe data
     }
 
     "must not decrypt data correctly if the key is incorrect" in {
       val data = "data"
-      val encryptedData = AesUtil.encrypt(data, "key")
-      val decryptedData = AesUtil.decrypt(encryptedData, "other key")
+      val secretKeySpec = AesUtil.buildSecretKey(data, 128)
+      val encryptedData = AesUtil.encrypt(data, secretKeySpec)
+      val anotherSecretKeySpec = AesUtil.buildSecretKey("data2", 128)
+      val decryptedData = AesUtil.decrypt(encryptedData, anotherSecretKeySpec)
       decryptedData must not be data
     }
-
   }
-
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.2-SNAPSHOT"
+version in ThisBuild := "0.1.2-SIMACAN-SNAPSHOT"


### PR DESCRIPTION
- AES key was defaulting to the maximum allowed key-size, causing incompatibilities between those who have installed the JCE and those who have not.
- Eventual solution should be to use PKCS#7 (Cryptographic Message Syntax Standard)